### PR TITLE
Typo: refer given example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ VCR.configure do |config|
 end
 
 RSpec.configure do |config|
-  config.around(:each, type: :request) do |ex|
+  config.around(:each, type: :request) do |example|
     host! "yourapp.hostname"
     name = example.full_description.gsub /[^\w\-]/, '_'
     VCR.use_cassette(name, record: :all) do
-      ex.run
+      example.run
     end
   end
 end


### PR DESCRIPTION
Typo in README?

We should not use `example` method in the exampe context. The RSpec error says:

```
 `example` is not available from within an example (e.g. an `it` block) or from constructs that run in the scope of an example (e.g. `before`, `let`, etc). It is only available on an example group (e.g. a `describe` or `context` block).
```
